### PR TITLE
Fix msvc2019 winx64 compile issue

### DIFF
--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -310,7 +310,8 @@ public:
 
     ReadInterface(ReadFunc &read_func, size_t length) : read_func_(read_func), length_(length) {
 #ifndef II_DISABLE_HEADER_CACHE
-        header_cache_.alloc(std::min((size_t)II_HEADER_CACHE_SIZE, length));
+        size_t min = length < II_HEADER_CACHE_SIZE ? length : II_HEADER_CACHE_SIZE;
+        header_cache_.alloc(min);
         read(header_cache_.data(), 0, header_cache_.size());
 #endif
     }
@@ -737,7 +738,7 @@ bool try_icns(ReadInterface &ri, size_t length, ImageInfo &info) {
         uint32_t entry_size = buffer.read_u32_be(4);
         int64_t s = size_map.at(type);
         entry_sizes.emplace_back(s, s);
-        max_size = std::max(max_size, s);
+        max_size = max_size > s ? max_size : s;
         offset += entry_size;
     }
 

--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -30,6 +30,12 @@
 #ifndef IMAGEINFO_IMAGEINFO_H
 #define IMAGEINFO_IMAGEINFO_H
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#else
+#define DEFINED_NOMINMAX
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -310,8 +316,7 @@ public:
 
     ReadInterface(ReadFunc &read_func, size_t length) : read_func_(read_func), length_(length) {
 #ifndef II_DISABLE_HEADER_CACHE
-        size_t min = length < II_HEADER_CACHE_SIZE ? length : II_HEADER_CACHE_SIZE;
-        header_cache_.alloc(min);
+        header_cache_.alloc(std::min((size_t)II_HEADER_CACHE_SIZE, length));
         read(header_cache_.data(), 0, header_cache_.size());
 #endif
     }
@@ -738,7 +743,7 @@ bool try_icns(ReadInterface &ri, size_t length, ImageInfo &info) {
         uint32_t entry_size = buffer.read_u32_be(4);
         int64_t s = size_map.at(type);
         entry_sizes.emplace_back(s, s);
-        max_size = max_size > s ? max_size : s;
+        max_size = std::max(max_size, s);
         offset += entry_size;
     }
 
@@ -1191,6 +1196,10 @@ inline ImageInfo parse(InputType &input,                                //
 
 #ifdef __clang__
 #pragma clang diagnostic pop
+#endif
+
+#ifndef DEFINED_NOMINMAX
+#undef NOMINMAX
 #endif
 
 #endif  // IMAGEINFO_IMAGEINFO_H

--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -30,12 +30,6 @@
 #ifndef IMAGEINFO_IMAGEINFO_H
 #define IMAGEINFO_IMAGEINFO_H
 
-#ifndef NOMINMAX
-#define NOMINMAX
-#else
-#define DEFINED_NOMINMAX
-#endif
-
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -316,7 +310,7 @@ public:
 
     ReadInterface(ReadFunc &read_func, size_t length) : read_func_(read_func), length_(length) {
 #ifndef II_DISABLE_HEADER_CACHE
-        header_cache_.alloc(std::min((size_t)II_HEADER_CACHE_SIZE, length));
+        header_cache_.alloc((std::min)((size_t)II_HEADER_CACHE_SIZE, length));
         read(header_cache_.data(), 0, header_cache_.size());
 #endif
     }
@@ -743,7 +737,7 @@ bool try_icns(ReadInterface &ri, size_t length, ImageInfo &info) {
         uint32_t entry_size = buffer.read_u32_be(4);
         int64_t s = size_map.at(type);
         entry_sizes.emplace_back(s, s);
-        max_size = std::max(max_size, s);
+        max_size = (std::max)(max_size, s);
         offset += entry_size;
     }
 
@@ -1196,10 +1190,6 @@ inline ImageInfo parse(InputType &input,                                //
 
 #ifdef __clang__
 #pragma clang diagnostic pop
-#endif
-
-#ifndef DEFINED_NOMINMAX
-#undef NOMINMAX
 #endif
 
 #endif  // IMAGEINFO_IMAGEINFO_H


### PR DESCRIPTION
Such a great lightweight header file to get basic image information for 20 different formats. I'd also look for a chance to get `*.exr` information but still good enough to get by. Tested on MacOS Ventura (M1 Chip arm64), Linux (x64), and Windows(x64) platforms. One issue that I've got so far is shown in the below picture which you may wanna consider:
![msvc2019_err](https://github.com/xiaozhuai/imageinfo/assets/75934597/4bceaa5b-193e-44d9-a918-00b32bee3cb0)
Still, I'll provide a hot fix with this PR anyway. Have a good one!