### PR TITLE
Make `imageinfo::parse` take input as const reference

### DIFF
--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -1178,7 +1178,7 @@ inline ImageInfo parse(ReadInterface &ri,                               //
 }
 
 template <typename ReaderType, typename InputType>
-inline ImageInfo parse(InputType &input,                                //
+inline ImageInfo parse(const InputType &input,                          //
                        const std::vector<Format> &likely_formats = {},  //
                        bool must_be_one_of_likely_formats = false) {    //
     ReaderType reader(input);


### PR DESCRIPTION
This allows it to compile the example given in the README file.
```c++
auto info = imageinfo::parse<imageinfo::RawDataReader>(imageinfo::RawData(data, size));
```