### PR TITLE
Add `very_likely_format`

### DIFF
--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -1109,10 +1109,10 @@ inline bool try_tga(ReadInterface &ri, size_t length, ImageInfo &info) {
 
 using Detector = bool (*)(ReadInterface &ri, size_t length, ImageInfo &info);
 
-inline ImageInfo parse(ReadInterface &ri,                              //
-                       Format very_likely_format,                      //
-                       const std::vector<Format> &likely_formats = {}, //
-                       bool must_be_one_of_likely_formats = false) {   //
+inline ImageInfo parse(ReadInterface &ri,                               //
+                       Format very_likely_format,                       //
+                       const std::vector<Format> &likely_formats = {},  //
+                       bool must_be_one_of_likely_formats = false) {    //
     size_t length = ri.length();
 
     std::vector<std::tuple<Format, Detector>> dl = {
@@ -1147,8 +1147,7 @@ inline ImageInfo parse(ReadInterface &ri,                              //
 
     ImageInfo info;
 
-    if(very_likely_format != Format::kFormatUnknown)
-    {
+    if (very_likely_format != Format::kFormatUnknown) {
         auto &detector = dm[very_likely_format];
         tried.insert(detector);
         if (detector(ri, length, info)) {
@@ -1187,17 +1186,17 @@ inline ImageInfo parse(ReadInterface &ri,                              //
     return ImageInfo(kUnrecognizedFormat);
 }
 
-inline ImageInfo parse(ReadInterface &ri,                              //
-                       const std::vector<Format> &likely_formats = {}, //
-                       bool must_be_one_of_likely_formats = false) {   //
+inline ImageInfo parse(ReadInterface &ri,                               //
+                       const std::vector<Format> &likely_formats = {},  //
+                       bool must_be_one_of_likely_formats = false) {    //
     return parse(ri, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
 }
 
 template <typename ReaderType, typename InputType>
-inline ImageInfo parse(const InputType &input,                         //
-                       Format very_likely_format,                      //
-                       const std::vector<Format> &likely_formats = {}, //
-                       bool must_be_one_of_likely_formats = false) {   //
+inline ImageInfo parse(const InputType &input,                          //
+                       Format very_likely_format,                       //
+                       const std::vector<Format> &likely_formats = {},  //
+                       bool must_be_one_of_likely_formats = false) {    //
     ReaderType reader(input);
     size_t length = reader.size();
     ReadFunc read_func = [&reader](void *buf, off_t offset, size_t size) { reader.read(buf, offset, size); };
@@ -1206,9 +1205,9 @@ inline ImageInfo parse(const InputType &input,                         //
 }
 
 template <typename ReaderType, typename InputType>
-inline ImageInfo parse(const InputType &input,                         //
-                       const std::vector<Format> &likely_formats = {}, //
-                       bool must_be_one_of_likely_formats = false) {   //
+inline ImageInfo parse(const InputType &input,                          //
+                       const std::vector<Format> &likely_formats = {},  //
+                       bool must_be_one_of_likely_formats = false) {    //
     return parse<ReaderType>(input, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
 }
 

--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -1186,10 +1186,11 @@ inline ImageInfo parse(ReadInterface &ri,                              //
 
     return ImageInfo(kUnrecognizedFormat);
 }
-inline ImageInfo parse(ReadInterface &ri,                                  //
-                       const std::vector<Format> &likely_formats = {},     //
-                       bool must_be_one_of_likely_formats = false) {       //
-	return parse(ri, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
+
+inline ImageInfo parse(ReadInterface &ri,                              //
+                       const std::vector<Format> &likely_formats = {}, //
+                       bool must_be_one_of_likely_formats = false) {   //
+    return parse(ri, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
 }
 
 template <typename ReaderType, typename InputType>
@@ -1205,9 +1206,9 @@ inline ImageInfo parse(const InputType &input,                         //
 }
 
 template <typename ReaderType, typename InputType>
-inline ImageInfo parse(const InputType &input,                             //
-                       const std::vector<Format> &likely_formats = {},     //
-                       bool must_be_one_of_likely_formats = false) {       //
+inline ImageInfo parse(const InputType &input,                         //
+                       const std::vector<Format> &likely_formats = {}, //
+                       bool must_be_one_of_likely_formats = false) {   //
     return parse<ReaderType>(input, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
 }
 

--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -1109,9 +1109,10 @@ inline bool try_tga(ReadInterface &ri, size_t length, ImageInfo &info) {
 
 using Detector = bool (*)(ReadInterface &ri, size_t length, ImageInfo &info);
 
-inline ImageInfo parse(ReadInterface &ri,                               //
-                       const std::vector<Format> &likely_formats = {},  //
-                       bool must_be_one_of_likely_formats = false) {    //
+inline ImageInfo parse(ReadInterface &ri,                              //
+                       Format very_likely_format,                      //
+                       const std::vector<Format> &likely_formats = {}, //
+                       bool must_be_one_of_likely_formats = false) {   //
     size_t length = ri.length();
 
     std::vector<std::tuple<Format, Detector>> dl = {
@@ -1146,6 +1147,15 @@ inline ImageInfo parse(ReadInterface &ri,                               //
 
     ImageInfo info;
 
+    if(very_likely_format != Format::kFormatUnknown)
+    {
+        auto &detector = dm[very_likely_format];
+        tried.insert(detector);
+        if (detector(ri, length, info)) {
+            return info;
+        }
+    }
+
     if (!likely_formats.empty()) {
         for (auto format : likely_formats) {
             auto &detector = dm[format];
@@ -1176,16 +1186,29 @@ inline ImageInfo parse(ReadInterface &ri,                               //
 
     return ImageInfo(kUnrecognizedFormat);
 }
+inline ImageInfo parse(ReadInterface &ri,                                  //
+                       const std::vector<Format> &likely_formats = {},     //
+                       bool must_be_one_of_likely_formats = false) {       //
+	return parse(ri, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
+}
 
 template <typename ReaderType, typename InputType>
-inline ImageInfo parse(const InputType &input,                          //
-                       const std::vector<Format> &likely_formats = {},  //
-                       bool must_be_one_of_likely_formats = false) {    //
+inline ImageInfo parse(const InputType &input,                         //
+                       Format very_likely_format,                      //
+                       const std::vector<Format> &likely_formats = {}, //
+                       bool must_be_one_of_likely_formats = false) {   //
     ReaderType reader(input);
     size_t length = reader.size();
     ReadFunc read_func = [&reader](void *buf, off_t offset, size_t size) { reader.read(buf, offset, size); };
     ReadInterface ri(read_func, length);
-    return parse(ri, likely_formats, must_be_one_of_likely_formats);
+    return parse(ri, very_likely_format, likely_formats, must_be_one_of_likely_formats);
+}
+
+template <typename ReaderType, typename InputType>
+inline ImageInfo parse(const InputType &input,                             //
+                       const std::vector<Format> &likely_formats = {},     //
+                       bool must_be_one_of_likely_formats = false) {       //
+    return parse<ReaderType>(input, Format::kFormatUnknown, likely_formats, must_be_one_of_likely_formats);
 }
 
 };  // namespace imageinfo

--- a/include/imageinfo.hpp
+++ b/include/imageinfo.hpp
@@ -1110,7 +1110,7 @@ inline bool try_tga(ReadInterface &ri, size_t length, ImageInfo &info) {
 using Detector = bool (*)(ReadInterface &ri, size_t length, ImageInfo &info);
 
 inline ImageInfo parse(ReadInterface &ri,                               //
-                       Format very_likely_format,                       //
+                       Format most_likely_format,                       //
                        const std::vector<Format> &likely_formats = {},  //
                        bool must_be_one_of_likely_formats = false) {    //
     size_t length = ri.length();
@@ -1147,8 +1147,8 @@ inline ImageInfo parse(ReadInterface &ri,                               //
 
     ImageInfo info;
 
-    if (very_likely_format != Format::kFormatUnknown) {
-        auto &detector = dm[very_likely_format];
+    if (most_likely_format != Format::kFormatUnknown) {
+        auto &detector = dm[most_likely_format];
         tried.insert(detector);
         if (detector(ri, length, info)) {
             return info;
@@ -1194,14 +1194,14 @@ inline ImageInfo parse(ReadInterface &ri,                               //
 
 template <typename ReaderType, typename InputType>
 inline ImageInfo parse(const InputType &input,                          //
-                       Format very_likely_format,                       //
+                       Format most_likely_format,                       //
                        const std::vector<Format> &likely_formats = {},  //
                        bool must_be_one_of_likely_formats = false) {    //
     ReaderType reader(input);
     size_t length = reader.size();
     ReadFunc read_func = [&reader](void *buf, off_t offset, size_t size) { reader.read(buf, offset, size); };
     ReadInterface ri(read_func, length);
-    return parse(ri, very_likely_format, likely_formats, must_be_one_of_likely_formats);
+    return parse(ri, most_likely_format, likely_formats, must_be_one_of_likely_formats);
 }
 
 template <typename ReaderType, typename InputType>


### PR DESCRIPTION
Keeps compatibility with the older API.

Allows the programmer to give a hint to the library to try parsing a certain format that it is sure to a good extent is going to be true.

Closes #7 